### PR TITLE
Develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libarchive-tools
+
       - name: Generate Prisma client
         run: npm run prisma:generate
 


### PR DESCRIPTION
This pull request adds a step to the release workflow to ensure that required Linux build dependencies are installed before generating the Prisma client. This helps prevent build failures due to missing system libraries.

- **CI/CD workflow improvements:**
  * [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R65-R69): Added a step to install `libarchive-tools` on Linux to ensure all necessary dependencies are available for the build process.