### PR TITLE
fix(update): check all releases to support prereleases & drafts

### DIFF
--- a/electron/src/services/update/update.service.spec.ts
+++ b/electron/src/services/update/update.service.spec.ts
@@ -22,11 +22,13 @@ describe('UpdateService', () => {
         html_url:
           'https://github.com/altaskur/OpenTimeTracker/releases/tag/v2.0.0',
         body: 'Release notes for v2.0.0',
+        draft: false,
+        prerelease: false,
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockRelease),
+        json: () => Promise.resolve([mockRelease]),
       });
 
       const result = await updateService.checkForUpdates();
@@ -43,11 +45,13 @@ describe('UpdateService', () => {
         html_url:
           'https://github.com/altaskur/OpenTimeTracker/releases/tag/v1.0.0',
         body: 'Current version notes',
+        draft: false,
+        prerelease: false,
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockRelease),
+        json: () => Promise.resolve([mockRelease]),
       });
 
       const result = await updateService.checkForUpdates();
@@ -62,11 +66,13 @@ describe('UpdateService', () => {
         html_url:
           'https://github.com/altaskur/OpenTimeTracker/releases/tag/v0.9.0',
         body: 'Old version notes',
+        draft: false,
+        prerelease: false,
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockRelease),
+        json: () => Promise.resolve([mockRelease]),
       });
 
       const result = await updateService.checkForUpdates();
@@ -103,17 +109,50 @@ describe('UpdateService', () => {
         html_url:
           'https://github.com/altaskur/OpenTimeTracker/releases/tag/2.0.0',
         body: 'Notes',
+        draft: false,
+        prerelease: false,
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockRelease),
+        json: () => Promise.resolve([mockRelease]),
       });
 
       const result = await updateService.checkForUpdates();
 
       expect(result.updateAvailable).toBe(true);
       expect(result.version).toBe('2.0.0');
+    });
+
+    it('should ignore draft releases', async () => {
+      const mockReleases = [
+        {
+          tag_name: 'v2.0.0',
+          html_url:
+            'https://github.com/altaskur/OpenTimeTracker/releases/tag/v2.0.0',
+          body: 'Draft release',
+          draft: true,
+          prerelease: false,
+        },
+        {
+          tag_name: 'v1.0.0',
+          html_url:
+            'https://github.com/altaskur/OpenTimeTracker/releases/tag/v1.0.0',
+          body: 'Release notes',
+          draft: false,
+          prerelease: false,
+        },
+      ];
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockReleases),
+      });
+
+      const result = await updateService.checkForUpdates();
+
+      expect(result.updateAvailable).toBe(false);
+      expect(result.version).toBe('1.0.0');
     });
   });
 
@@ -124,6 +163,8 @@ describe('UpdateService', () => {
         html_url:
           'https://github.com/altaskur/OpenTimeTracker/releases/tag/v1.0.0',
         body: 'Release notes for v1.0.0',
+        draft: false,
+        prerelease: false,
       };
 
       mockFetch.mockResolvedValue({

--- a/electron/src/services/update/update.service.ts
+++ b/electron/src/services/update/update.service.ts
@@ -11,11 +11,13 @@ interface GitHubRelease {
   tag_name: string;
   html_url: string;
   body: string;
+  draft: boolean;
+  prerelease: boolean;
 }
 
 export class UpdateService {
   private readonly GITHUB_API_URL =
-    'https://api.github.com/repos/altaskur/OpenTimeTracker/releases/latest';
+    'https://api.github.com/repos/altaskur/OpenTimeTracker/releases';
 
   async checkForUpdates(): Promise<UpdateCheckResult> {
     try {
@@ -31,8 +33,15 @@ export class UpdateService {
         return { updateAvailable: false, version: '', url: '' };
       }
 
-      const release = (await response.json()) as GitHubRelease;
-      const latestVersion = release.tag_name.replace(/^v/, '');
+      const releases = (await response.json()) as GitHubRelease[];
+      // Filter out drafts, but allow prereleases since we are in alpha
+      const latestRelease = releases.find((r) => !r.draft);
+
+      if (!latestRelease) {
+        return { updateAvailable: false, version: '', url: '' };
+      }
+
+      const latestVersion = latestRelease.tag_name.replace(/^v/, '');
       const currentVersion = app.getVersion();
 
       const updateAvailable =
@@ -41,8 +50,8 @@ export class UpdateService {
       return {
         updateAvailable,
         version: latestVersion,
-        url: release.html_url,
-        releaseNotes: release.body,
+        url: latestRelease.html_url,
+        releaseNotes: latestRelease.body,
       };
     } catch (error) {
       console.error('Error checking for updates:', error);


### PR DESCRIPTION
This pull request updates the update-checking logic and its tests to support fetching and handling multiple GitHub releases, specifically filtering out draft releases. This ensures that only published (non-draft) releases are considered for updates, improving the reliability of the update feature.

**Update logic improvements:**

* Changed the GitHub API endpoint in `UpdateService` from fetching only the latest release to fetching all releases, allowing more control over which releases are considered.
* Updated the logic in `checkForUpdates` to filter out draft releases and select the most recent non-draft release as the latest available version.
* Modified the returned update information to use the selected non-draft release's details.

**Type and test updates:**

* Added `draft` and `prerelease` fields to the `GitHubRelease` interface and updated all test mocks to include these fields. [[1]](diffhunk://#diff-d4e377c3554d6dabf5a5383a4760a9dd3205956e8c43697f78ce592f86f2fa38R14-R20) [[2]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R25-R31) [[3]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R48-R54) [[4]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R69-R75) [[5]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R166-R167)
* Updated tests to mock the API response as an array of releases, and added a new test to verify that draft releases are ignored by the update logic. [[1]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R25-R31) [[2]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R48-R54) [[3]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R69-R75) [[4]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R112-R156)