### PR TITLE
Develop

### DIFF
--- a/electron/src/services/update/update.service.spec.ts
+++ b/electron/src/services/update/update.service.spec.ts
@@ -22,11 +22,13 @@ describe('UpdateService', () => {
         html_url:
           'https://github.com/altaskur/OpenTimeTracker/releases/tag/v2.0.0',
         body: 'Release notes for v2.0.0',
+        draft: false,
+        prerelease: false,
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockRelease),
+        json: () => Promise.resolve([mockRelease]),
       });
 
       const result = await updateService.checkForUpdates();
@@ -43,11 +45,13 @@ describe('UpdateService', () => {
         html_url:
           'https://github.com/altaskur/OpenTimeTracker/releases/tag/v1.0.0',
         body: 'Current version notes',
+        draft: false,
+        prerelease: false,
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockRelease),
+        json: () => Promise.resolve([mockRelease]),
       });
 
       const result = await updateService.checkForUpdates();
@@ -62,11 +66,13 @@ describe('UpdateService', () => {
         html_url:
           'https://github.com/altaskur/OpenTimeTracker/releases/tag/v0.9.0',
         body: 'Old version notes',
+        draft: false,
+        prerelease: false,
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockRelease),
+        json: () => Promise.resolve([mockRelease]),
       });
 
       const result = await updateService.checkForUpdates();
@@ -103,17 +109,50 @@ describe('UpdateService', () => {
         html_url:
           'https://github.com/altaskur/OpenTimeTracker/releases/tag/2.0.0',
         body: 'Notes',
+        draft: false,
+        prerelease: false,
       };
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockRelease),
+        json: () => Promise.resolve([mockRelease]),
       });
 
       const result = await updateService.checkForUpdates();
 
       expect(result.updateAvailable).toBe(true);
       expect(result.version).toBe('2.0.0');
+    });
+
+    it('should ignore draft releases', async () => {
+      const mockReleases = [
+        {
+          tag_name: 'v2.0.0',
+          html_url:
+            'https://github.com/altaskur/OpenTimeTracker/releases/tag/v2.0.0',
+          body: 'Draft release',
+          draft: true,
+          prerelease: false,
+        },
+        {
+          tag_name: 'v1.0.0',
+          html_url:
+            'https://github.com/altaskur/OpenTimeTracker/releases/tag/v1.0.0',
+          body: 'Release notes',
+          draft: false,
+          prerelease: false,
+        },
+      ];
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockReleases),
+      });
+
+      const result = await updateService.checkForUpdates();
+
+      expect(result.updateAvailable).toBe(false);
+      expect(result.version).toBe('1.0.0');
     });
   });
 
@@ -124,6 +163,8 @@ describe('UpdateService', () => {
         html_url:
           'https://github.com/altaskur/OpenTimeTracker/releases/tag/v1.0.0',
         body: 'Release notes for v1.0.0',
+        draft: false,
+        prerelease: false,
       };
 
       mockFetch.mockResolvedValue({

--- a/electron/src/services/update/update.service.ts
+++ b/electron/src/services/update/update.service.ts
@@ -11,11 +11,13 @@ interface GitHubRelease {
   tag_name: string;
   html_url: string;
   body: string;
+  draft: boolean;
+  prerelease: boolean;
 }
 
 export class UpdateService {
   private readonly GITHUB_API_URL =
-    'https://api.github.com/repos/altaskur/OpenTimeTracker/releases/latest';
+    'https://api.github.com/repos/altaskur/OpenTimeTracker/releases';
 
   async checkForUpdates(): Promise<UpdateCheckResult> {
     try {
@@ -31,8 +33,15 @@ export class UpdateService {
         return { updateAvailable: false, version: '', url: '' };
       }
 
-      const release = (await response.json()) as GitHubRelease;
-      const latestVersion = release.tag_name.replace(/^v/, '');
+      const releases = (await response.json()) as GitHubRelease[];
+      // Filter out drafts, but allow prereleases since we are in alpha
+      const latestRelease = releases.find((r) => !r.draft);
+
+      if (!latestRelease) {
+        return { updateAvailable: false, version: '', url: '' };
+      }
+
+      const latestVersion = latestRelease.tag_name.replace(/^v/, '');
       const currentVersion = app.getVersion();
 
       const updateAvailable =
@@ -41,8 +50,8 @@ export class UpdateService {
       return {
         updateAvailable,
         version: latestVersion,
-        url: release.html_url,
-        releaseNotes: release.body,
+        url: latestRelease.html_url,
+        releaseNotes: latestRelease.body,
       };
     } catch (error) {
       console.error('Error checking for updates:', error);


### PR DESCRIPTION
This pull request updates the update checking logic and tests for the `UpdateService` to handle multiple releases from the GitHub API, filter out draft releases, and improve test coverage for these scenarios. The main focus is ensuring that only non-draft releases are considered for updates, and the code and tests now expect the GitHub API to return an array of releases.

**Update logic improvements:**

* Changed the GitHub releases API URL in `UpdateService` to fetch all releases instead of just the latest, and updated the logic to filter out draft releases while still allowing prereleases. [[1]](diffhunk://#diff-d4e377c3554d6dabf5a5383a4760a9dd3205956e8c43697f78ce592f86f2fa38R14-R20) [[2]](diffhunk://#diff-d4e377c3554d6dabf5a5383a4760a9dd3205956e8c43697f78ce592f86f2fa38L34-R44)
* Modified the update check result to use the first non-draft release's information for version, URL, and release notes.

**Test updates:**

* Updated all relevant tests in `update.service.spec.ts` to expect an array of releases from the mock API, and added the `draft` and `prerelease` fields to mock release objects. [[1]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R25-R31) [[2]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R48-R54) [[3]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R69-R75) [[4]](diffhunk://#diff-5ed093264030334e502bda7bea117608fa04d18eb8c186f14d38c0a86dad71c8R166-R167)
* Added a new test case to verify that draft releases are ignored when checking for updates.

**Type/interface changes:**

* Added `draft` and `prerelease` properties to the `GitHubRelease` interface to match the fields returned by the GitHub API.
